### PR TITLE
chore: removed unnecessary DialogVariant type in dialogstates

### DIFF
--- a/src/routes/kiosk/state_management/-dialog_states.ts
+++ b/src/routes/kiosk/state_management/-dialog_states.ts
@@ -1,8 +1,6 @@
 import { create } from "zustand";
-import { Counter, Ticket } from "@/utils/types/kiosk_types";
+import { Counter, Ticket, DialogVariant } from "@/utils/types/kiosk_types";
 import { ticketTypes } from "@/utils/variables/kiosk_variables";
-
-type DialogVariant = "confirmation" | "success" | "error";
 
 type DialogStore = {
   isOpen: boolean;


### PR DESCRIPTION
Closes #8 
In this commit I

- removed unnecessary DialogVariant type in dialogstates
- used the DialogVariant type in kiosk_types.ts instead