### PR TITLE
feat: added initial layout for AdminDashboard

### DIFF
--- a/src/routes/admin/-AdminHeader.tsx
+++ b/src/routes/admin/-AdminHeader.tsx
@@ -2,8 +2,8 @@
 
 export default function AdminHeader() {
     return (
-        <div className="flex items-center justify-between px-10 pt-6 pb-3">
-          <p className="text-3xl font-bold">Header Title</p>
+        <div className="flex items-center justify-between px-8 pt-6 pb-3">
+          <p className="text-xl font-bold"><span className="font-normal">Good Morning,</span> User!</p>
           <div className="flex items-center gap-10">
             <img src="/notification.svg" className="size-5" />
             <div className="flex items-center gap-[10px]">

--- a/src/routes/admin/_admin-layout.tsx
+++ b/src/routes/admin/_admin-layout.tsx
@@ -5,7 +5,7 @@ import AdminHeader from "./-AdminHeader";
 
 export const Route = createFileRoute("/admin/_admin-layout")({
   component: () => (
-    <div className="flex h-screen font-poppins">
+    <div className="flex h-screen font-poppins text-main_primary">
       <Navbar />
       <div className="flex flex-col flex-1">
         <AdminHeader/>

--- a/src/routes/admin/_admin-layout/dashboard/components/admin/-AdminDashboard.tsx
+++ b/src/routes/admin/_admin-layout/dashboard/components/admin/-AdminDashboard.tsx
@@ -1,0 +1,15 @@
+import AnalayticsSection from "./-AnalyticsSection";
+import AppointmentsSection from "./-AppointmentsSection";
+import QueueingSection from "./-QueueingSection"
+
+export default function AdminDashboard() {
+  return (
+    <div className="flex flex-1 gap-5 px-8 pb-6">
+      <div className="flex flex-col flex-1 gap-5">
+        <QueueingSection/>
+        <AnalayticsSection/>
+      </div>
+      <AppointmentsSection/>
+    </div>
+  );
+}

--- a/src/routes/admin/_admin-layout/dashboard/components/admin/-AnalyticsSection.tsx
+++ b/src/routes/admin/_admin-layout/dashboard/components/admin/-AnalyticsSection.tsx
@@ -1,0 +1,3 @@
+export default function AnalayticsSection() {
+  return <div className="flex-1 rounded-2xl bg-main_extra">ANALYTICS</div>;
+}

--- a/src/routes/admin/_admin-layout/dashboard/components/admin/-AppointmentsSection.tsx
+++ b/src/routes/admin/_admin-layout/dashboard/components/admin/-AppointmentsSection.tsx
@@ -1,0 +1,7 @@
+export default function AppointmentsSection() {
+  return (
+    <div className="w-[35%] bg-main_extra rounded-2xl">
+      UPCOMING APPOINTMENTS
+    </div>
+  );
+}

--- a/src/routes/admin/_admin-layout/dashboard/components/admin/-QueueingSection.tsx
+++ b/src/routes/admin/_admin-layout/dashboard/components/admin/-QueueingSection.tsx
@@ -1,0 +1,50 @@
+const temp_tickets = [
+    {
+      counter: 1,
+      ticketNum: "R-145",
+    },
+    {
+      counter: 2,
+      ticketNum: "R-552",
+    },
+    {
+      counter: 1,
+      ticketNum: "T-123",
+    },
+    {
+      counter: 3,
+      ticketNum: "X-442",
+    },
+    {
+      counter: 5,
+      ticketNum: "Y-111",
+    },
+    {
+      counter: 6,
+      ticketNum: "R-888",
+    },
+  ];
+export default function QueueingSection() {
+  return (
+    <div className="flex-1 p-6 rounded-2xl bg-main_extra">
+      <div className="flex flex-col gap-6 size-full">
+        <div className="flex items-center justify-between">
+          <p className="text-lg font-semibold">Queueing</p>
+          <button className="py-2 text-sm text-white rounded-md px-7 bg-main_primary">
+            Open Queue
+          </button>
+        </div>
+        <div className="grid grid-cols-3 grid-rows-2 gap-y-2 gap-x-2 size-full">
+          {temp_tickets.map((ticket, i) => {
+            return (
+              <div key={i} className="flex flex-col justify-center gap-1 py-2 text-center bg-white rounded-xl ">
+                <p className="text-lg">Counter {ticket.counter}</p>
+                <p className="text-4xl font-semibold">{ticket.ticketNum}</p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/admin/_admin-layout/dashboard/components/staff/-StaffDashboard.tsx
+++ b/src/routes/admin/_admin-layout/dashboard/components/staff/-StaffDashboard.tsx
@@ -1,0 +1,7 @@
+
+
+export default function StaffDashboard() {
+    return (
+        <div></div>
+    )
+}

--- a/src/routes/admin/_admin-layout/dashboard/index.tsx
+++ b/src/routes/admin/_admin-layout/dashboard/index.tsx
@@ -1,13 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
+import AdminDashboard from './components/admin/-AdminDashboard'
+import StaffDashboard from './components/staff/-StaffDashboard'
+
+const temp_user = "admin"
 
 export const Route = createFileRoute('/admin/_admin-layout/dashboard/')({
   component: () => <Dashboard/>
 })
 
+
 function Dashboard() {
   return (
-    <div className='grid flex-1 place-content-center'>
-        DASHBOARD
-    </div>
+    temp_user==="admin" ? <AdminDashboard/> : <StaffDashboard/>
   )
 }


### PR DESCRIPTION
#34 
In this commit I:

- added initial layour for AdminDashboard
- created separate components for AdminDashboard and StaffDashboard
- separated AdminDashboard into different components (Analytics, Queueing, and Appointments)
- modified dashboard/index.tsx to render either AdminDashboard or StaffDashboard