### PR TITLE
feat: user authentication caching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,25 @@
-import { RouterProvider, createRouter } from '@tanstack/react-router'
+import { RouterProvider, createRouter } from "@tanstack/react-router";
 
 // Import the generated route tree
-import { routeTree } from './routeTree.gen'
+import { routeTree } from "./routeTree.gen";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 // Create a new router instance
-const router = createRouter({ routeTree })
+const router = createRouter({ routeTree });
 
 // Register the router instance for type safety
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface Register {
-    router: typeof router
+    router: typeof router;
   }
 }
 const queryClient = new QueryClient();
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-  <RouterProvider router={router}/>
-  </QueryClientProvider>
-  )
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { RouterProvider, createRouter } from '@tanstack/react-router'
 
 // Import the generated route tree
 import { routeTree } from './routeTree.gen'
-
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 // Create a new router instance
 const router = createRouter({ routeTree })
 
@@ -12,9 +12,13 @@ declare module '@tanstack/react-router' {
     router: typeof router
   }
 }
-
+const queryClient = new QueryClient();
 function App() {
-  return <RouterProvider router={router}/>
+  return (
+    <QueryClientProvider client={queryClient}>
+  <RouterProvider router={router}/>
+  </QueryClientProvider>
+  )
 }
 
 export default App;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,12 @@
 import axios from "axios";
+import {
+  QueryClient,
+  UseQueryResult,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { LoginData } from "@/utils/types/auth_types";
 
 const BASE_URL = "/api/core/auth";
 
@@ -10,7 +18,6 @@ type LoginCredentials = {
 export const login = async (credentials: LoginCredentials) => {
   try {
     const response = await axios.post(`${BASE_URL}/login`, credentials);
-    console.log(response);
     return response;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
@@ -20,3 +27,23 @@ export const login = async (credentials: LoginCredentials) => {
   }
 };
 
+export function useLoginMutation(queryClient: QueryClient) {
+  return useMutation({
+    mutationFn: login,
+    onSuccess: (response) => {
+      console.log(response.data.data);
+      queryClient.setQueryData<LoginData>(["userData"], response.data.data);
+    },
+  });
+}
+
+export function useCachedUserData() {
+  return useQuery<LoginData, Error>({
+    queryKey: ["userData"],
+    enabled: false,
+    // staleTime: Infinity,
+    // refetchOnWindowFocus: false,
+    // refetchOnMount: false,
+    // retry: false,
+  });
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,7 +6,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { LoginData } from "@/utils/types/auth_types";
+import { UserData } from "@/utils/types/auth_types";
 
 const BASE_URL = "/api/core/auth";
 
@@ -27,23 +27,30 @@ export const login = async (credentials: LoginCredentials) => {
   }
 };
 
-export function useLoginMutation(queryClient: QueryClient) {
-  return useMutation({
-    mutationFn: login,
-    onSuccess: (response) => {
-      console.log(response.data.data);
-      queryClient.setQueryData<LoginData>(["userData"], response.data.data);
-    },
-  });
-}
+// export function useLoginMutation(queryClient: QueryClient) {
+//   return useMutation({
+//     mutationFn: login,
+//     onSuccess: (response) => {
+//       console.log(response.data.data);
+//       queryClient.setQueryData<UserData>(["userData"], response.data.data);
+//     },
+//   });
+// }
 
-export function useCachedUserData() {
-  return useQuery<LoginData, Error>({
+
+
+
+export function useUserData() {
+  return useQuery<UserData>({
     queryKey: ["userData"],
-    enabled: false,
-    // staleTime: Infinity,
-    // refetchOnWindowFocus: false,
-    // refetchOnMount: false,
-    // retry: false,
+    queryFn: async () => {
+      console.log('fetching from useUserData');
+      const { data: userData } = await axios.get(`/api/core/user/profile`);
+      return userData.data as UserData;
+    },
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    retry: false,
   });
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -11,8 +11,8 @@ const queryClient = new QueryClient();
 
 export const Route = createRootRoute({
   component: () => (
-    <QueryClientProvider client={queryClient}>
+    
       <Outlet />
-    </QueryClientProvider>
+    
   ),
 });

--- a/src/routes/admin/-AdminHeader.tsx
+++ b/src/routes/admin/-AdminHeader.tsx
@@ -1,15 +1,7 @@
-import { useCachedUserData } from "@/api/auth";
-import { useQueryClient } from "@tanstack/react-query";
-import { LoginData } from "@/utils/types/auth_types";
+import { useUserData } from "@/api/auth";
 
 export default function AdminHeader() {
-  // const queryClient = useQueryClient();
-  const { data: cachedUserData, error } = useCachedUserData();
-  const getUserDataLocalStorage = localStorage.getItem("userDataLocalStorage")
-  const userDataLocalStorage = getUserDataLocalStorage && JSON.parse(getUserDataLocalStorage) as LoginData
-  // const cachedUserData = queryClient.getQueryData<LoginData>(["userData"]);
-  // console.log("THIS IS FROM ADMINHEADER", userDataLocalStorage);
-  console.log("THIS IS FROM ADMINHEADER", cachedUserData);
+  const {data: userData, error} = useUserData()
 
   return (
     <div className="flex items-center justify-between px-8 pt-6 pb-3">
@@ -21,14 +13,11 @@ export default function AdminHeader() {
         <div className="flex items-center gap-[10px]">
           <img src="/user-icon.svg" className="size-5" />
           <p className="text-sm font-bold">
-            {userDataLocalStorage
-                ? `${userDataLocalStorage.firstName} ${userDataLocalStorage.lastName}`
-                : "Loading..."}
-            {/* {error
+            {error
               ? error.message
-              : cachedUserData
-                ? `${cachedUserData.firstName} ${cachedUserData.lastName}`
-                : "Loading..."} */}
+              : userData
+                ? `${userData.firstName} ${userData.lastName}`
+                : "Loading..."}
           </p>
         </div>
       </div>

--- a/src/routes/admin/-AdminHeader.tsx
+++ b/src/routes/admin/-AdminHeader.tsx
@@ -1,16 +1,37 @@
-
+import { useCachedUserData } from "@/api/auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { LoginData } from "@/utils/types/auth_types";
 
 export default function AdminHeader() {
-    return (
-        <div className="flex items-center justify-between px-8 pt-6 pb-3">
-          <p className="text-xl font-bold"><span className="font-normal">Good Morning,</span> User!</p>
-          <div className="flex items-center gap-10">
-            <img src="/notification.svg" className="size-5" />
-            <div className="flex items-center gap-[10px]">
-              <img src="/user-icon.svg" className="size-5" />
-              <p className="text-sm font-bold">John Doe</p>
-            </div>
-          </div>
+  // const queryClient = useQueryClient();
+  const { data: cachedUserData, error } = useCachedUserData();
+  const getUserDataLocalStorage = localStorage.getItem("userDataLocalStorage")
+  const userDataLocalStorage = getUserDataLocalStorage && JSON.parse(getUserDataLocalStorage) as LoginData
+  // const cachedUserData = queryClient.getQueryData<LoginData>(["userData"]);
+  // console.log("THIS IS FROM ADMINHEADER", userDataLocalStorage);
+  console.log("THIS IS FROM ADMINHEADER", cachedUserData);
+
+  return (
+    <div className="flex items-center justify-between px-8 pt-6 pb-3">
+      <p className="text-xl font-bold">
+        <span className="font-normal">Good Morning,</span> User!
+      </p>
+      <div className="flex items-center gap-10">
+        <img src="/notification.svg" className="size-5" />
+        <div className="flex items-center gap-[10px]">
+          <img src="/user-icon.svg" className="size-5" />
+          <p className="text-sm font-bold">
+            {userDataLocalStorage
+                ? `${userDataLocalStorage.firstName} ${userDataLocalStorage.lastName}`
+                : "Loading..."}
+            {/* {error
+              ? error.message
+              : cachedUserData
+                ? `${cachedUserData.firstName} ${cachedUserData.lastName}`
+                : "Loading..."} */}
+          </p>
         </div>
-    )
+      </div>
+    </div>
+  );
 }

--- a/src/routes/admin/_admin-layout/appointments/-AppointmentsCalendar.tsx
+++ b/src/routes/admin/_admin-layout/appointments/-AppointmentsCalendar.tsx
@@ -161,6 +161,7 @@ export default function AppointmentCalendar() {
             {weekDates.map((weekDate, dateIndex) => {
               return (
                 <div
+                key={dateIndex}
                   className={`relative flex-1 flex flex-col items-center ${
                     dateIndex !== weekDates.length - 1 ? "border-r" : ""
                   } border-calendar_borders`}

--- a/src/routes/admin/_admin-layout/monitor-management/-MiniMonitorPreview.tsx
+++ b/src/routes/admin/_admin-layout/monitor-management/-MiniMonitorPreview.tsx
@@ -1,40 +1,43 @@
 export default function MiniMonitorPreview() {
-    return (
-      <div className="flex flex-col w-full h-48 bg-white">
-        <div className="flex justify-between px-4 py-1 bg-main_primary">
-          <div className="flex items-center gap-2">
-            <img src="/kiosk-logo.png" className="size-4" />
-            <div className="space-y-[1px] text-white">
-              <p className="text-[7px] font-bold">KIOSK</p>
-              <p className="text-[4px]">Queueing and Billing System</p>
-            </div>
-          </div>
-          <div className="flex flex-col items-end justify-center gap-[1px] text-white text-[4px]">
-            <p className="">January 15, 2025</p>
-            <p>03:34:12 PM</p>
+  return (
+    <div className="flex flex-col w-full h-48 bg-white">
+      <div className="flex justify-between px-4 py-1 bg-main_primary">
+        <div className="flex items-center gap-2">
+          <img src="/kiosk-logo.png" className="size-4" />
+          <div className="space-y-[1px] text-white">
+            <p className="text-[7px] font-bold">KIOSK</p>
+            <p className="text-[4px]">Queueing and Billing System</p>
           </div>
         </div>
-        <div className="flex flex-1 mb-4">
-          <div className="flex-1 space-y-[1px] flex flex-col py-2 pr-2 pl-6 gap-1">
-            <p className="font-bold text-[7px]">Now Serving</p>
-            <div className="grid flex-1 grid-cols-2 grid-rows-4 gap-x-1 gap-y-1 py-[1px] px-[1px]">
-              {Array.from({ length: 8 }).map((ticket, index) => {
-                return (
-                  <div className="rounded-md minimonitorcard-shadow text-main_primary size-full py-[1px] flex flex-col items-center justify-center">
-                    <p className="text-[4px]">Counter 1</p>
-                    <p className="text-[8px] font-bold">S-003</p>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-          <div className="flex-1">
-            <img
-              src={"/justforlaughs.png"}
-              className="object-cover object-center size-full"
-            />
-          </div>
+        <div className="flex flex-col items-end justify-center gap-[1px] text-white text-[4px]">
+          <p className="">January 15, 2025</p>
+          <p>03:34:12 PM</p>
         </div>
       </div>
-    );
-  }
+      <div className="flex flex-1 mb-4">
+        <div className="flex-1 space-y-[1px] flex flex-col py-2 pr-2 pl-6 gap-1">
+          <p className="font-bold text-[7px]">Now Serving</p>
+          <div className="grid flex-1 grid-cols-2 grid-rows-4 gap-x-1 gap-y-1 py-[1px] px-[1px]">
+            {Array.from({ length: 8 }).map((ticket, index) => {
+              return (
+                <div
+                  key={index}
+                  className="rounded-md minimonitorcard-shadow text-main_primary size-full py-[1px] flex flex-col items-center justify-center"
+                >
+                  <p className="text-[4px]">Counter 1</p>
+                  <p className="text-[8px] font-bold">S-003</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div className="flex-1">
+          <img
+            src={"/justforlaughs.png"}
+            className="object-cover object-center size-full"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/admin/_admin-layout/monitor-management/add-monitor/-AddCategoryDialog.tsx
+++ b/src/routes/admin/_admin-layout/monitor-management/add-monitor/-AddCategoryDialog.tsx
@@ -40,6 +40,7 @@ export default function AddCategoryDialog() {
               {Array.from({ length: 10 }).map((counter, index) => {
                 return (
                   <div
+                  key={index}
                     className={`flex ${index + 1 < 4 ? "bg-calendar_borders" : index + 1 === 4 ? "bg-main_primary text-white" : "bg-white"} rounded-lg min-h-24`}
                   >
                     <div className="flex items-center justify-center flex-1 text-3xl font-bold">

--- a/src/routes/admin/index.tsx
+++ b/src/routes/admin/index.tsx
@@ -1,5 +1,22 @@
-import { Navigate, createFileRoute } from '@tanstack/react-router'
+import { Navigate, createFileRoute } from "@tanstack/react-router";
+import { useCachedUserData } from "@/api/auth";
+// import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { LoginData } from "@/utils/types/auth_types";
 
-export const Route = createFileRoute('/admin/')({
-  component: () => <Navigate to='/admin/login' replace={true}/>
-})
+export const Route = createFileRoute("/admin/")({
+  component: () => <Admin />,
+});
+
+function Admin() {
+  // const queryClient = useQueryClient()
+  const getUserDataLocalStorage = localStorage.getItem("userDataLocalStorage")
+  const userDataLocalStorage = getUserDataLocalStorage && JSON.parse(getUserDataLocalStorage) as LoginData
+  // const cachedUserData = queryClient.getQueryData<LoginData>(['userData'])
+  const { data: cachedUserData } = useCachedUserData();
+  console.log("THIS IS FROM INDEX.TSX", cachedUserData);
+
+  if (userDataLocalStorage) {
+    return <Navigate to="/admin/dashboard" replace={true} />;
+  }
+  return <Navigate to="/admin/login" replace={true} />;
+}

--- a/src/routes/admin/index.tsx
+++ b/src/routes/admin/index.tsx
@@ -1,22 +1,6 @@
 import { Navigate, createFileRoute } from "@tanstack/react-router";
-import { useCachedUserData } from "@/api/auth";
-// import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { LoginData } from "@/utils/types/auth_types";
 
 export const Route = createFileRoute("/admin/")({
-  component: () => <Admin />,
+  component: () => <Navigate to="/admin/login" replace={true} />
 });
 
-function Admin() {
-  // const queryClient = useQueryClient()
-  const getUserDataLocalStorage = localStorage.getItem("userDataLocalStorage")
-  const userDataLocalStorage = getUserDataLocalStorage && JSON.parse(getUserDataLocalStorage) as LoginData
-  // const cachedUserData = queryClient.getQueryData<LoginData>(['userData'])
-  const { data: cachedUserData } = useCachedUserData();
-  console.log("THIS IS FROM INDEX.TSX", cachedUserData);
-
-  if (userDataLocalStorage) {
-    return <Navigate to="/admin/dashboard" replace={true} />;
-  }
-  return <Navigate to="/admin/login" replace={true} />;
-}

--- a/src/routes/admin/login/components/-Login.tsx
+++ b/src/routes/admin/login/components/-Login.tsx
@@ -1,5 +1,5 @@
-"use client";
-
+import { LoginData } from "@/utils/types/auth_types";
+import { useLoginMutation } from "@/api/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import {
@@ -14,14 +14,14 @@ import { Input } from "@/components/ui/input";
 import { IconLoader2 } from "@tabler/icons-react";
 import { login } from "@/api/auth";
 import { useNavigate } from "@tanstack/react-router";
-
+import { QueryClient, useQueryClient } from "@tanstack/react-query";
 const loginSchema = z.object({
   username: z.string().min(1, "Username is required"),
   password: z.string().min(1, "Password is required"),
 });
 
 export default function Login() {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   const form = useForm<z.infer<typeof loginSchema>>({
     resolver: zodResolver(loginSchema),
     mode: "onSubmit",
@@ -32,13 +32,17 @@ export default function Login() {
     },
   });
 
+  const queryClient = useQueryClient();
+  // const loginMutation = useLoginMutation(queryClient);
+
   async function onSubmit(values: z.infer<typeof loginSchema>) {
     try {
       const response = await login(values);
       if (response.status === 200) {
-        console.log("Login successful:", response.data);
+        localStorage.setItem("userDataLocalStorage", JSON.stringify(response.data.data))
+        queryClient.setQueryData<LoginData>(['userData'], response.data.data)
         form.reset();
-        navigate({to: '/admin/dashboard'})
+        navigate({ to: "/admin/dashboard" });
       } else {
         const errorMessage = response.data.errors[0].message || "Login failed";
         form.setError("username", {
@@ -133,4 +137,3 @@ export default function Login() {
     </div>
   );
 }
-

--- a/src/routes/admin/login/components/-Login.tsx
+++ b/src/routes/admin/login/components/-Login.tsx
@@ -1,5 +1,5 @@
-import { LoginData } from "@/utils/types/auth_types";
-import { useLoginMutation } from "@/api/auth";
+
+import { UserData } from "@/utils/types/auth_types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import {
@@ -14,7 +14,7 @@ import { Input } from "@/components/ui/input";
 import { IconLoader2 } from "@tabler/icons-react";
 import { login } from "@/api/auth";
 import { useNavigate } from "@tanstack/react-router";
-import { QueryClient, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 const loginSchema = z.object({
   username: z.string().min(1, "Username is required"),
   password: z.string().min(1, "Password is required"),
@@ -33,14 +33,12 @@ export default function Login() {
   });
 
   const queryClient = useQueryClient();
-  // const loginMutation = useLoginMutation(queryClient);
-
   async function onSubmit(values: z.infer<typeof loginSchema>) {
     try {
       const response = await login(values);
       if (response.status === 200) {
-        localStorage.setItem("userDataLocalStorage", JSON.stringify(response.data.data))
-        queryClient.setQueryData<LoginData>(['userData'], response.data.data)
+        const userData = response.data.data as UserData
+        queryClient.setQueryData<UserData>(['userData'], userData)
         form.reset();
         navigate({ to: "/admin/dashboard" });
       } else {

--- a/src/routes/admin/login/index.tsx
+++ b/src/routes/admin/login/index.tsx
@@ -1,10 +1,32 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { Navigate, createFileRoute } from "@tanstack/react-router";
 import Login from "./components/-Login";
+import { useUserData } from "@/api/auth";
 
 export const Route = createFileRoute("/admin/login/")({
-  component: () => (
+  component: () => <AdminLogin />,
+});
+
+
+function AdminLogin() {
+  const {
+    data: userData,
+    isLoading,
+  } = useUserData();
+
+  if (isLoading) {
+    return (
+      <div className="grid h-screen text-3xl place-items-center text-main_primary">
+        Checking credentials...
+      </div>
+    );
+  }
+  if (userData) {
+    return <Navigate to="/admin/dashboard"/>;
+  }
+  
+  return (
     <div className="grid h-screen bg-main_primary place-items-center">
       <Login />
     </div>
-  ),
-});
+  );
+}

--- a/src/utils/types/auth_types.ts
+++ b/src/utils/types/auth_types.ts
@@ -1,0 +1,30 @@
+export type LoginData = {
+    id:                string;
+    email:             string;
+    username:          string;
+    provider:          string;
+    avatarUrl:         null;
+    firstName:         string;
+    lastName:          string;
+    hasProfilePicture: boolean;
+    confirmedAt:       Date;
+    createdAt:         Date;
+    updatedAt:         Date;
+    status:            number;
+    timezone:          number;
+    timezoneId:        null;
+    language:          null;
+    areaCodes:         AreaCode[];
+    authorities:       Authority[];
+    token:             null;
+}
+
+export type AreaCode = {
+    id:     string;
+    code:   string;
+    status: number;
+}
+
+export type Authority = {
+    authority: string;
+}

--- a/src/utils/types/auth_types.ts
+++ b/src/utils/types/auth_types.ts
@@ -1,4 +1,4 @@
-export type LoginData = {
+export type UserData = {
     id:                string;
     email:             string;
     username:          string;


### PR DESCRIPTION
Closes #61 
In this PR I:

- implemented autonavigate to dashboard if user navigates to /admin or /admin/login if user is currnetly logged in.
- did by providing a queryFunction that fetches user data from /api/core/user/profile and setting it as the cache data.
- removed localStorage implementation since userData is always available in cache if currently logged in
- reverted /admin index route to navigating directly to /admin/login, since /admin/login will do all the login authentication
- /admin/login now accesses userData in cache using useQuery and shows loading component if loading, navigating to dashboard if userData exists, else, just rendering the login page (if userData is undefined or if there is an error in the useQuery's queryFn).
- renamed LoginData type to UserData
- added key prop to some components